### PR TITLE
Fixes to hashing in set_state

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -382,7 +382,7 @@ void Position::set_state(StateInfo* si) const {
   si->psq += PSQT::psq[W_HAWK][SQUARE_NB] * si->inHand[WHITE][0] + PSQT::psq[W_ELEPHANT][SQUARE_NB] * si->inHand[WHITE][1];
   si->psq += PSQT::psq[B_HAWK][SQUARE_NB] * si->inHand[BLACK][0] + PSQT::psq[B_ELEPHANT][SQUARE_NB] * si->inHand[BLACK][1];
   si->key ^= Zobrist::psq[W_HAWK][SQUARE_NB] * si->inHand[WHITE][0] ^ Zobrist::psq[W_ELEPHANT][SQUARE_NB] * si->inHand[WHITE][1];
-  si->key ^= Zobrist::psq[B_HAWK][SQUARE_NB] * si->inHand[WHITE][0] ^ Zobrist::psq[B_ELEPHANT][SQUARE_NB] * si->inHand[WHITE][1];
+  si->key ^= Zobrist::psq[B_HAWK][SQUARE_NB] * si->inHand[BLACK][0] ^ Zobrist::psq[B_ELEPHANT][SQUARE_NB] * si->inHand[BLACK][1];
 
   if (si->epSquare != SQ_NONE)
       si->key ^= Zobrist::enpassant[file_of(si->epSquare)];
@@ -897,7 +897,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       st->psq +=  PSQT::psq[gating_piece][gating_square]
                 - PSQT::psq[gating_piece][SQUARE_NB];
       k ^= Zobrist::psq[gating_piece][gating_square] ^ Zobrist::psq[gating_piece][SQUARE_NB];
-      st->materialKey ^= Zobrist::psq[gating_piece][pieceCount[gating_piece]];
+      st->materialKey ^= Zobrist::psq[gating_piece][pieceCount[gating_piece]-1];
       st->nonPawnMaterial[us] += PieceValue[MG][gating_piece];
   }
 
@@ -1238,8 +1238,8 @@ bool Position::pos_is_ok() const {
 
   if (   (pieces(WHITE) & pieces(BLACK))
       || (pieces(WHITE) | pieces(BLACK)) != pieces()
-      || popcount(pieces(WHITE)) > 16
-      || popcount(pieces(BLACK)) > 16)
+      || popcount(pieces(WHITE)) > 18
+      || popcount(pieces(BLACK)) > 18)
       assert(0 && "pos_is_ok: Bitboards");
 
   for (PieceType p1 = PAWN; p1 <= KING; ++p1)


### PR DESCRIPTION
OK this is the first pull request and just contains a single patch.

First of all you can verify that in current master setting Fast to false in the function pos_is_ok gives assertion errors when run in debug mode. The same is hopefully not true with this patch.

In master, whenever a piece is removed from hand by either side all the hash keys change at the root. At best this means that master will miss out on TT information from previous searches and at worst there could be damaging hash collisions.

This is the patch that I ran an SPRT(-40,0) test on that passed quite easily. I was running at 5+0.05 with book and the result was:

```
LLR: 3.07 (-2.94,2.94) [-40.00,0.00]
Total: 106 W: 45 L: 30 D:31
```

This patch changes the bench number. All of the patches that I will put in the next PR will preserve the bench number but since there is a merge conflict (a fairly trivial one) I will wait until you decide on this patch before continuing.