### PR TITLE
Move Hawk/Elephant two spots down

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -181,7 +181,7 @@ void Bitboards::init() {
               DistanceRingBB[s1][SquareDistance[s1][s2] - 1] |= s2;
           }
 
-  int steps[][5] = { {}, { 7, 9 }, { 6, 10, 15, 17 }, {}, {}, {}, { 1, 7, 8, 9 } };
+  int steps[][5] = { {}, { 7, 9 }, { 6, 10, 15, 17 }, {}, {}, {}, {}, {}, { 1, 7, 8, 9 } };
 
   for (Color c = WHITE; c <= BLACK; ++c)
       for (PieceType pt : { PAWN, KNIGHT, KING })

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -254,9 +254,9 @@ inline Bitboard attacks_bb(PieceType pt, Square s, Bitboard occupied) {
   {
   case BISHOP   : return attacks_bb<BISHOP>(s, occupied);
   case ROOK     : return attacks_bb<  ROOK>(s, occupied);
-  case QUEEN    : return attacks_bb<BISHOP>(s, occupied) | attacks_bb<ROOK>(s, occupied);
   case HAWK     : return PseudoAttacks[KNIGHT][s] | attacks_bb<BISHOP>(s, occupied);
   case ELEPHANT : return PseudoAttacks[KNIGHT][s] | attacks_bb<  ROOK>(s, occupied);
+  case QUEEN    : return attacks_bb<BISHOP>(s, occupied) | attacks_bb<ROOK>(s, occupied);
   default       : return PseudoAttacks[pt][s];
   }
 }

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -171,8 +171,7 @@ namespace {
       S( 28, 61), S( 41, 73), S( 43, 79), S( 48, 92), S( 56, 94), S( 60,104),
       S( 60,113), S( 66,120), S( 67,123), S( 70,126), S( 71,133), S( 73,136),
       S( 79,140), S( 88,143), S( 88,148), S( 99,166), S(102,170), S(102,175),
-      S(106,184), S(109,191), S(113,206), S(116,212) },
-    {} // King
+      S(106,184), S(109,191), S(113,206), S(116,212) }
   };
 
   // Outpost[knight/bishop][supported by pawn] contains bonuses for minor
@@ -217,7 +216,7 @@ namespace {
   };
 
   // KingProtector[PieceType-2] contains a bonus according to distance from king
-  const Score KingProtector[] = { S(-3, -5), S(-4, -3), S(-3, 0), S(0, 0), S(0, 0), S(-1, 1), S(0, 0) };
+  const Score KingProtector[] = { S(-3, -5), S(-4, -3), S(-3, 0), S(0, 0), S(0, 0), S(-1, 1) };
 
   // Assorted bonuses and penalties used by evaluation
   const Score MinorBehindPawn     = S( 16,  0);
@@ -242,7 +241,7 @@ namespace {
   #undef V
 
   // KingAttackWeights[PieceType] contains king attack weights by piece type
-  const int KingAttackWeights[PIECE_TYPE_NB] = { 0, 0, 78, 56, 45, 10, 10, 11, 0 };
+  const int KingAttackWeights[PIECE_TYPE_NB] = { 0, 0, 78, 56, 45, 10, 10, 11 };
 
   // Penalties for enemy's safe checks
   const int QueenCheck  = 780;

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -39,6 +39,8 @@ namespace {
     {  32,  255,  -3                    }, // Knight      OUR PIECES
     {   0,  104,   4,    0              }, // Bishop
     { -26,   -2,  47,   105,  -149      }, // Rook
+    {   0,    0,   0,     0,     0,   0 }, // Hawk
+    {   0,    0,   0,     0,     0,   0 }, // Elephant
     {-185,   24, 122,   137,  -134,   0 }  // Queen
   };
 
@@ -50,6 +52,8 @@ namespace {
     {   9,   63,   0                    }, // Knight      OUR PIECES
     {  59,   65,  42,     0             }, // Bishop
     {  46,   39,  24,   -24,    0       }, // Rook
+    {   0,    0,   0,     0,    0,    0 }, // Hawk
+    {   0,    0,   0,     0,    0,    0 }, // Elephant
     { 101,  100, -37,   141,  268,    0 }  // Queen
   };
 
@@ -231,10 +235,14 @@ Entry* probe(const Position& pos) {
   // for the bishop pair "extended piece", which allows us to be more flexible
   // in defining bishop pair bonuses.
   const int PieceCount[COLOR_NB][PIECE_TYPE_NB] = {
-  { pos.count<BISHOP>(WHITE) > 1, pos.count<PAWN>(WHITE), pos.count<KNIGHT>(WHITE),
-    pos.count<BISHOP>(WHITE)    , pos.count<ROOK>(WHITE), pos.count<QUEEN >(WHITE) },
-  { pos.count<BISHOP>(BLACK) > 1, pos.count<PAWN>(BLACK), pos.count<KNIGHT>(BLACK),
-    pos.count<BISHOP>(BLACK)    , pos.count<ROOK>(BLACK), pos.count<QUEEN >(BLACK) } };
+  { pos.count<BISHOP>(WHITE) > 1, pos.count<PAWN>(WHITE),
+    pos.count<KNIGHT>(WHITE)    , pos.count<BISHOP>(WHITE),
+    pos.count<ROOK>(WHITE)      , pos.count<HAWK>(WHITE),
+    pos.count<ELEPHANT>(WHITE)  , pos.count<QUEEN>(WHITE) },
+  { pos.count<BISHOP>(BLACK) > 1, pos.count<PAWN>(BLACK),
+    pos.count<KNIGHT>(BLACK)    , pos.count<BISHOP>(BLACK),
+    pos.count<ROOK>(BLACK)      , pos.count<HAWK>(BLACK),
+    pos.count<ELEPHANT>(BLACK)  , pos.count<QUEEN>(BLACK) } };
 
   e->value = int16_t((imbalance<WHITE>(PieceCount) - imbalance<BLACK>(PieceCount)) / 16);
   return e;

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -32,29 +32,29 @@ namespace {
   // Polynomial material imbalance parameters
 
   const int QuadraticOurs[][PIECE_TYPE_NB] = {
-    //            OUR PIECES
-    // pair pawn knight bishop rook queen
-    {1667                               }, // Bishop pair
-    {  40,    0                         }, // Pawn
-    {  32,  255,  -3                    }, // Knight      OUR PIECES
-    {   0,  104,   4,    0              }, // Bishop
-    { -26,   -2,  47,   105,  -149      }, // Rook
-    {   0,    0,   0,     0,     0,   0 }, // Hawk
-    {   0,    0,   0,     0,     0,   0 }, // Elephant
-    {-185,   24, 122,   137,  -134,   0 }  // Queen
+    //                     OUR PIECES
+    // pair pawn knight  bishop   rook  hawk elephant queen
+    {1667                                                  }, // Bishop pair
+    {  40,     0                                           }, // Pawn
+    {  32,   255,    -3                                    }, // Knight
+    {   0,   104,     4,     0                             }, // Bishop      OUR PIECES
+    { -26,    -2,    47,   105,  -149                      }, // Rook
+    {   0,     0,     0,     0,     0,     0               }, // Hawk
+    {   0,     0,     0,     0,     0,     0,     0        }, // Elephant
+    {-185,    24,   122,   137,  -134,     0,     0,     0 }  // Queen
   };
 
   const int QuadraticTheirs[][PIECE_TYPE_NB] = {
-    //           THEIR PIECES
-    // pair pawn knight bishop rook queen
-    {   0                               }, // Bishop pair
-    {  36,    0                         }, // Pawn
-    {   9,   63,   0                    }, // Knight      OUR PIECES
-    {  59,   65,  42,     0             }, // Bishop
-    {  46,   39,  24,   -24,    0       }, // Rook
-    {   0,    0,   0,     0,    0,    0 }, // Hawk
-    {   0,    0,   0,     0,    0,    0 }, // Elephant
-    { 101,  100, -37,   141,  268,    0 }  // Queen
+    //                    THEIR PIECES
+    // pair pawn knight  bishop   rook  hawk elephant queen
+    {   0                                                  }, // Bishop pair
+    {  36,     0                                           }, // Pawn
+    {   9,    63,     0                                    }, // Knight
+    {  59,    65,    42,     0                             }, // Bishop      OUR PIECES
+    {  46,    39,    24,   -24,     0                      }, // Rook
+    {   0,     0,     0,     0,     0,     0               }, // Hawk
+    {   0,     0,     0,     0,     0,     0,     0        }, // Elephant
+    { 101,   100,   -37,   141,   268,     0,     0,     0 }  // Queen
   };
 
   // PawnSet[pawn count] contains a bonus/malus indexed by number of pawns

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -77,7 +77,7 @@ namespace {
   ExtMove* make_promotions(ExtMove* moveList, Square to, Square ksq) {
 
     if (Type == CAPTURES || Type == EVASIONS || Type == NON_EVASIONS)
-        *moveList++ = make<PROMOTION>(to - D, to, QUEEN);
+        *moveList++ = make<PROMOTION2>(to - D, to, QUEEN);
 
     if (Type == QUIETS || Type == EVASIONS || Type == NON_EVASIONS)
     {
@@ -290,9 +290,9 @@ namespace {
     moveList = generate_moves<  KNIGHT, Checks>(pos, moveList, Us, target);
     moveList = generate_moves<  BISHOP, Checks>(pos, moveList, Us, target);
     moveList = generate_moves<    ROOK, Checks>(pos, moveList, Us, target);
-    moveList = generate_moves<   QUEEN, Checks>(pos, moveList, Us, target);
     moveList = generate_moves<    HAWK, Checks>(pos, moveList, Us, target);
     moveList = generate_moves<ELEPHANT, Checks>(pos, moveList, Us, target);
+    moveList = generate_moves<   QUEEN, Checks>(pos, moveList, Us, target);
 
     if (Type != QUIET_CHECKS && Type != EVASIONS)
     {

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -67,15 +67,15 @@ PieceType min_attacker(const Bitboard* bb, Square to, Bitboard stmAttackers,
 
   Bitboard b = stmAttackers & bb[Pt];
   if (!b)
-      return min_attacker<Pt == ELEPHANT ? QUEEN : (Pt == ROOK ? HAWK : Pt + 1)>(bb, to, stmAttackers, occupied, attackers);
+      return min_attacker<Pt + 1>(bb, to, stmAttackers, occupied, attackers);
 
   occupied ^= b & ~(b - 1);
 
-  if (Pt == PAWN || Pt == BISHOP || Pt == QUEEN || Pt == HAWK)
-      attackers |= attacks_bb<BISHOP>(to, occupied) & (bb[BISHOP] | bb[QUEEN] | bb[HAWK]);
+  if (Pt == PAWN || Pt == BISHOP || Pt == HAWK || Pt == QUEEN)
+      attackers |= attacks_bb<BISHOP>(to, occupied) & (bb[BISHOP] | bb[HAWK] | bb[QUEEN]);
 
-  if (Pt == ROOK || Pt == QUEEN || Pt == ELEPHANT)
-      attackers |= attacks_bb<ROOK>(to, occupied) & (bb[ROOK] | bb[QUEEN] | bb[ELEPHANT]);
+  if (Pt == ROOK || Pt == ELEPHANT || Pt == QUEEN)
+      attackers |= attacks_bb<ROOK>(to, occupied) & (bb[ROOK] | bb[ELEPHANT] | bb[QUEEN]);
 
   attackers &= occupied; // After X-ray that may add already processed pieces
   return (PieceType)Pt;
@@ -897,7 +897,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   // Add gating piece
   if (is_gating(m))
   {
-      assert(gating_type(m) >= HAWK && gating_type(m) <= QUEEN);
+      assert(gating_type(m) >= HAWK && gating_type(m) <= ELEPHANT);
 
       Square gating_square = gating_on_castling_rook(m) ? to_sq(m) : from_sq(m);
       Piece gating_piece = make_piece(sideToMove, gating_type(m));

--- a/src/position.h
+++ b/src/position.h
@@ -299,9 +299,9 @@ template<PieceType Pt>
 inline Bitboard Position::attacks_from(Square s) const {
   assert(Pt != PAWN);
   return  Pt == BISHOP || Pt == ROOK ? attacks_bb<Pt>(s, byTypeBB[ALL_PIECES])
-        : Pt == QUEEN    ? attacks_from<ROOK>(s) | attacks_from<BISHOP>(s)
         : Pt == HAWK     ? PseudoAttacks[KNIGHT][s] | attacks_from<BISHOP>(s)
         : Pt == ELEPHANT ? PseudoAttacks[KNIGHT][s] | attacks_from<  ROOK>(s)
+        : Pt == QUEEN    ? attacks_from<ROOK>(s) | attacks_from<BISHOP>(s)
         : PseudoAttacks[Pt][s];
 }
 

--- a/src/psqt.cpp
+++ b/src/psqt.cpp
@@ -23,8 +23,8 @@
 #include "types.h"
 
 Value PieceValue[PHASE_NB][PIECE_NB] = {
-  { VALUE_ZERO, PawnValueMg, KnightValueMg, BishopValueMg, RookValueMg, QueenValueMg, VALUE_ZERO, HawkValueMg, ElephantValueMg },
-  { VALUE_ZERO, PawnValueEg, KnightValueEg, BishopValueEg, RookValueEg, QueenValueEg, VALUE_ZERO, HawkValueEg, ElephantValueEg }
+  { VALUE_ZERO, PawnValueMg, KnightValueMg, BishopValueMg, RookValueMg, HawkValueMg, ElephantValueMg, QueenValueMg, VALUE_ZERO },
+  { VALUE_ZERO, PawnValueEg, KnightValueEg, BishopValueEg, RookValueEg, HawkValueEg, ElephantValueEg, QueenValueEg, VALUE_ZERO }
 };
 
 namespace PSQT {
@@ -76,26 +76,6 @@ const Score Bonus[][RANK_NB][int(FILE_NB) / 2] = {
    { S(-12, 0), S(  4, 0), S(  8, 0), S(12, 0) },
    { S(-23, 0), S(-15, 0), S(-11, 0), S(-5, 0) }
   },
-  { // Queen
-   { S( 0,-71), S(-4,-56), S(-3,-42), S(-1,-29) },
-   { S(-4,-56), S( 6,-30), S( 9,-21), S( 8, -5) },
-   { S(-2,-39), S( 6,-17), S( 9, -8), S( 9,  5) },
-   { S(-1,-29), S( 8, -5), S(10,  9), S( 7, 19) },
-   { S(-3,-27), S( 9, -5), S( 8, 10), S( 7, 21) },
-   { S(-2,-40), S( 6,-16), S( 8,-10), S(10,  3) },
-   { S(-2,-55), S( 7,-30), S( 7,-21), S( 6, -6) },
-   { S(-1,-74), S(-4,-55), S(-1,-43), S( 0,-30) }
-  },
-  { // King
-   { S(267,  0), S(320, 48), S(270, 75), S(195, 84) },
-   { S(264, 43), S(304, 92), S(238,143), S(180,132) },
-   { S(200, 83), S(245,138), S(176,167), S(110,165) },
-   { S(177,106), S(185,169), S(148,169), S(110,179) },
-   { S(149,108), S(177,163), S(115,200), S( 66,203) },
-   { S(118, 95), S(159,155), S( 84,176), S( 41,174) },
-   { S( 87, 50), S(128, 99), S( 63,122), S( 20,139) },
-   { S( 63,  9), S( 88, 55), S( 47, 80), S(  0, 90) }
-  },
   { // Hawk
    { S(-44,-58), S(-13,-31), S(-25,-37), S(-34,-19) },
    { S(-20,-34), S( 20, -9), S( 12,-14), S(  1,  4) },
@@ -115,6 +95,26 @@ const Score Bonus[][RANK_NB][int(FILE_NB) / 2] = {
    { S(-21, 0), S( -7, 0), S(  0, 0), S( 2, 0) },
    { S(-12, 0), S(  4, 0), S(  8, 0), S(12, 0) },
    { S(-23, 0), S(-15, 0), S(-11, 0), S(-5, 0) }
+  },
+  { // Queen
+   { S( 0,-71), S(-4,-56), S(-3,-42), S(-1,-29) },
+   { S(-4,-56), S( 6,-30), S( 9,-21), S( 8, -5) },
+   { S(-2,-39), S( 6,-17), S( 9, -8), S( 9,  5) },
+   { S(-1,-29), S( 8, -5), S(10,  9), S( 7, 19) },
+   { S(-3,-27), S( 9, -5), S( 8, 10), S( 7, 21) },
+   { S(-2,-40), S( 6,-16), S( 8,-10), S(10,  3) },
+   { S(-2,-55), S( 7,-30), S( 7,-21), S( 6, -6) },
+   { S(-1,-74), S(-4,-55), S(-1,-43), S( 0,-30) }
+  },
+  { // King
+   { S(267,  0), S(320, 48), S(270, 75), S(195, 84) },
+   { S(264, 43), S(304, 92), S(238,143), S(180,132) },
+   { S(200, 83), S(245,138), S(176,167), S(110,165) },
+   { S(177,106), S(185,169), S(148,169), S(110,179) },
+   { S(149,108), S(177,163), S(115,200), S( 66,203) },
+   { S(118, 95), S(159,155), S( 84,176), S( 41,174) },
+   { S( 87, 50), S(128, 99), S( 63,122), S( 20,139) },
+   { S( 63,  9), S( 88, 55), S( 47, 80), S(  0, 90) }
   }
 };
 
@@ -128,7 +128,7 @@ Score inhand[PIECE_NB];
 // tables are initialized by flipping and changing the sign of the white scores.
 void init() {
 
-  for (Piece pc = W_PAWN; pc <= W_ELEPHANT; ++pc)
+  for (Piece pc = W_PAWN; pc <= W_KING; ++pc)
   {
       PieceValue[MG][~pc] = PieceValue[MG][pc];
       PieceValue[EG][~pc] = PieceValue[EG][pc];

--- a/src/types.h
+++ b/src/types.h
@@ -111,14 +111,14 @@ const int MAX_PLY   = 128;
 /// bit 14-15: special move flag: promotion (1), en passant (2), castling (3)
 /// NOTE: EN-PASSANT bit is set only when a pawn can be captured
 ///
-/// Gating moves are encoded by adding (gated piece type - KING) in bits 12-13.
+/// Gating moves are encoded by adding (gated piece type - ROOK) in bits 12-13.
 ///
 /// For castling moves where a piece is gated on the rook square, bits 14-15
 /// are changed to PROMOTION in order to distinguish them from castling moves
 /// where the piece is gated on the king's origin square.
 ///
-/// Promotions to HAWK or ELEPHANT are encoded by settting bits 14-15 to ENPASSANT,
-/// and bits 12-13 are set to (promoted piece type - KING).
+/// Promotions to HAWK, ELEPHANT or QUEEN are encoded by settting bits 14-15
+/// to ENPASSANT, and bits 12-13 are set to (promoted piece type - ROOK).
 ///
 /// Special cases are MOVE_NONE and MOVE_NULL. We can sneak these in because in
 /// any normal move destination square is always different from origin square
@@ -206,15 +206,15 @@ enum Value : int {
 };
 
 enum PieceType {
-  NO_PIECE_TYPE, PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING, HAWK, ELEPHANT,
+  NO_PIECE_TYPE, PAWN, KNIGHT, BISHOP, ROOK, HAWK, ELEPHANT, QUEEN, KING,
   ALL_PIECES = 0,
   PIECE_TYPE_NB = 9
 };
 
 enum Piece {
   NO_PIECE,
-  W_PAWN = 1,  W_KNIGHT, W_BISHOP, W_ROOK, W_QUEEN, W_KING, W_HAWK, W_ELEPHANT,
-  B_PAWN = 10, B_KNIGHT, B_BISHOP, B_ROOK, B_QUEEN, B_KING, B_HAWK, B_ELEPHANT,
+  W_PAWN = 1,  W_KNIGHT, W_BISHOP, W_ROOK, W_HAWK, W_ELEPHANT, W_QUEEN, W_KING,
+  B_PAWN = 10, B_KNIGHT, B_BISHOP, B_ROOK, B_HAWK, B_ELEPHANT, B_QUEEN, B_KING,
   PIECE_NB = 18
 };
 
@@ -456,7 +456,7 @@ inline MoveType type_of(Move m) {
 
 inline PieceType promotion_type(Move m) {
   if ((m & (3 << 14)) == PROMOTION2)
-      return PieceType(((m >> 12) & 3) + KING);
+      return PieceType(((m >> 12) & 3) + ROOK);
   return PieceType(((m >> 12) & 3) + KNIGHT);
 }
 
@@ -466,13 +466,13 @@ inline Move make_move(Square from, Square to) {
 
 template<MoveType T>
 inline Move make(Square from, Square to, PieceType pt = KNIGHT) {
-  if (pt > KING)
-      return Move(T + ((pt - KING) << 12) + (from << 6) + to);
+  if (pt > ROOK)
+      return Move(T + ((pt - ROOK) << 12) + (from << 6) + to);
   return Move(T + ((pt - KNIGHT) << 12) + (from << 6) + to);
 }
 
 inline PieceType gating_type(Move m) {
-  return PieceType(((m >> 12) & 3) + KING);
+  return PieceType(((m >> 12) & 3) + ROOK);
 }
 
 inline bool is_ok(Move m) {

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -297,10 +297,10 @@ string UCI::move(Move m, bool chess960) {
   string move = UCI::square(from) + UCI::square(to);
 
   if (type_of(m) == PROMOTION)
-      move += " pnbrqkhe"[promotion_type(m)];
+      move += " pnbrheqk"[promotion_type(m)];
 
   else if (is_gating(m))
-      move += " pnbrqkhe"[gating_type(m)];
+      move += " pnbrheqk"[gating_type(m)];
 
   return move;
 }


### PR DESCRIPTION
I keep going while my interest in this is high.

This patch moves Hawk and Elephant two places down the PieceType list.

I keep Hawk and Elephant promotions using the PROMOTION2 type but also move Queen promotions there too. This isn't absolutely necessary but it keeps the make_move function simple. Now the piece type that encodes no gating is the Rook not the King. Probably I should have made an alias for this e.g. NO_GATE = ROOK but I forgot.

This patch changes bench but I claim that it is only for irrelevant reasons. See the branch https://github.com/ceebo/Seirawan-Stockfish/commits/ridiculous_fix that preserves the current bench number by introducing some ridiculous translations between new and old behaviour.

The only testing I have actually done on this branch is to run with debug=yes. If anything this branch is probably slightly slower than master because now the loops to calculate the material imbalance are longer but for no tangible benefit. I think it is worth it though in the long run.

I haven't actually enabled gating of Queen in this branch but it is pretty trivial to do so. Also I suppose that the FEN handling would need to be updated to allow Queen's in hand.

With all of the non-royal pieces consecutive this patch would open up some possibilities for cleaning up the move encoding a bit. I agree with your comment in the other PR that it would be better to keep type_of if possible. Getting rid of type_of should only be done if we find a move encoding that is a lot better than what we can achieve by keeping type_of.

Feel free to review/comment at your leisure.

