### PR TITLE
Change move encoding

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -77,23 +77,23 @@ namespace {
   ExtMove* make_promotions(ExtMove* moveList, Square to, Square ksq) {
 
     if (Type == CAPTURES || Type == EVASIONS || Type == NON_EVASIONS)
-        *moveList++ = make<PROMOTION2>(to - D, to, QUEEN);
+        *moveList++ = make<PROMOTION>(to - D, to, QUEEN);
 
     if (Type == QUIETS || Type == EVASIONS || Type == NON_EVASIONS)
     {
-        *moveList++ = make<PROMOTION2>(to - D, to, ELEPHANT);
-        *moveList++ = make<PROMOTION2>(to - D, to, HAWK);
-        *moveList++ = make<PROMOTION >(to - D, to, ROOK);
-        *moveList++ = make<PROMOTION >(to - D, to, BISHOP);
-        *moveList++ = make<PROMOTION >(to - D, to, KNIGHT);
+        *moveList++ = make<PROMOTION>(to - D, to, ELEPHANT);
+        *moveList++ = make<PROMOTION>(to - D, to, HAWK);
+        *moveList++ = make<PROMOTION>(to - D, to, ROOK);
+        *moveList++ = make<PROMOTION>(to - D, to, BISHOP);
+        *moveList++ = make<PROMOTION>(to - D, to, KNIGHT);
     }
 
     // Elephant/Hawk/Knight promotions are the only promotions that can give a direct check
     // that's not already included in the queen promotion.
     if (Type == QUIET_CHECKS && (PseudoAttacks[KNIGHT][to] & ksq))
     {
-        *moveList++ = make<PROMOTION2>(to - D, to, ELEPHANT);
-        *moveList++ = make<PROMOTION2>(to - D, to, HAWK);
+        *moveList++ = make<PROMOTION>(to - D, to, ELEPHANT);
+        *moveList++ = make<PROMOTION>(to - D, to, HAWK);
     }
     else
         (void)ksq; // Silence a warning under MSVC

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -616,7 +616,7 @@ bool Position::pseudo_legal(const Move m) const {
   
   // If the move gates a piece make sure we have that piece in hand
   // and that we are allowed to gate on the from square.
-  if (gating_type(m) != NO_GATE && !(in_hand(us, gating_type(m)) && (gates(us) & from)))
+  if (gating_type(m) != NO_GATE_TYPE && !(in_hand(us, gating_type(m)) && (gates(us) & from)))
       return false;
 
   // If the 'from' square is not occupied by a piece belonging to the side to
@@ -888,7 +888,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       st->rule50 = 0;
   }
 
-  else if (gating_type(m) != NO_GATE) // Safe because m is not a pawn move
+  else if (gating_type(m) != NO_GATE_TYPE) // Safe because m is not a pawn move
   {
       assert(gating_type(m) >= HAWK && gating_type(m) <= ELEPHANT);
 

--- a/src/types.h
+++ b/src/types.h
@@ -109,22 +109,22 @@ const int MAX_PLY   = 128;
 /// bit  6-11: origin square (from 0 to 63)
 /// bit 12-15: special bits as described below
 ///
-/// NORMAL moves have bits 14 and 15 set to 0. We encode gating of HAWK,
-/// ELEPHANT or QUEEN by adding (gated piece type - ROOK) in bits 12-13.
+/// NORMAL moves have bits 12 and 13 set to 0. We encode gating of HAWK,
+/// ELEPHANT or QUEEN by adding (gated piece type - ROOK) in bits 14-15.
 ///
-/// ENPASSANT moves are encoded with bit 14 set to 1 and bit 15 set to 0.
+/// ENPASSANT moves are encoded with bit 13 set to 1 and bit 12 set to 0.
 /// NOTE: ENPASSANT is set only when a pawn can be captured.
 ///
-/// PROMOTION and CASTLING moves have bit 15 set. We distinguish between
+/// PROMOTION and CASTLING moves have bit 12 set. We distinguish between
 /// promotions and castlings by checking the parities of the ranks of the to
 /// and from square. If they are different it is a PROMOTION otherwise it is
 /// a CASTLING. For technical reasons we do this test in bit 3 so it is
-/// convenient to set CASTLING = 1 << 15 and PROMOTION = CASTLING | 8.
+/// convenient to set CASTLING = 1 << 12 and PROMOTION = CASTLING | 8.
 ///
-/// With promotions and castlings we have bits 12-14 free to store further
+/// With promotions and castlings we have bits 13-15 free to store further
 /// information. For promotions we use these bits to encode the promotion
 /// type ranging from 2 for KNIGHT up to 7 for QUEEN. With castling moves we
-/// set bit 14 if gating takes place on the square of the rook. We encode
+/// set bit 13 if gating takes place on the square of the rook. We encode
 /// the gated piece just as for NORMAL moves.
 ///
 /// Special cases are MOVE_NONE and MOVE_NULL. We can sneak these in because in
@@ -138,10 +138,10 @@ enum Move : int {
 
 enum MoveType {
   NORMAL,
-  ENPASSANT = 1 << 14,
-  CASTLING  = 1 << 15,
-  PROMOTION = CASTLING | 8,
-  CASTLING2 = CASTLING | (1 << 14)
+  ENPASSANT = 1 << 13,
+  CASTLING  = 1 << 12,
+  PROMOTION = CASTLING | 8,        // The 8 is used in decoding not encoding.
+  CASTLING2 = CASTLING | (1 << 13) // Not returned by type_of. Just a helper.
 };
 
 enum Color {
@@ -215,7 +215,7 @@ enum PieceType {
   NO_PIECE_TYPE, PAWN, KNIGHT, BISHOP, ROOK, HAWK, ELEPHANT, QUEEN, KING,
   ALL_PIECES = 0,
   PIECE_TYPE_NB = 9,
-  NO_GATE = ROOK
+  NO_GATE_TYPE = ROOK
 };
 
 enum Piece {
@@ -450,26 +450,26 @@ inline MoveType type_of(Move m) {
 }
 
 inline bool is_normal(Move m) {
-  return !(m & (3 << 14));
+  return !(m & (3 << 12));
 }
 
 inline PieceType promotion_type(Move m) {
   assert(type_of(m) == PROMOTION);
-  return PieceType((m >> 12) - (CASTLING >> 12));
+  return PieceType(m >> 13);
 }
 
 inline bool is_gating(Move m) {
-  return (m & (3 << 12)) && (is_normal(m) || !((m ^ (m >> 6)) & 8));
+  return (m & (3 << 14)) && (is_normal(m) || !((m ^ (m >> 6)) & 8));
 }
 
 inline PieceType gating_type(Move m) {
   assert(type_of(m) == NORMAL || type_of(m) == CASTLING);
-  return PieceType(((m >> 12) & 3) + NO_GATE);
+  return PieceType((m >> 14) + NO_GATE_TYPE);
 }
 
 inline bool gating_on_to_sq(Move m) {
   assert(type_of(m) == NORMAL || type_of(m) == CASTLING);
-  return m & (1 << 14);
+  return m & (1 << 13);
 }
 
 inline Move make_move(Square from, Square to) {
@@ -477,9 +477,10 @@ inline Move make_move(Square from, Square to) {
 }
 
 template<MoveType T>
-inline Move make(Square from, Square to, PieceType pt = NO_GATE) {
-  PieceType pt_encode = pt - (T == PROMOTION ? NO_PIECE_TYPE : NO_GATE);
-  return Move((T & (3 << 14)) + (pt_encode << 12) + (from << 6) + to);
+inline Move make(Square from, Square to, PieceType pt = NO_GATE_TYPE) {
+  int      Shift = T == PROMOTION ? 13 : 14;
+  PieceType Base = T == PROMOTION ? NO_PIECE_TYPE : NO_GATE_TYPE;
+  return Move((T & (3 << 12)) + ((pt - Base) << Shift) + (from << 6) + to);
 }
 
 inline bool is_ok(Move m) {

--- a/src/types.h
+++ b/src/types.h
@@ -107,18 +107,25 @@ const int MAX_PLY   = 128;
 ///
 /// bit  0- 5: destination square (from 0 to 63)
 /// bit  6-11: origin square (from 0 to 63)
-/// bit 12-13: promotion piece type - 2 (from KNIGHT-2 to QUEEN-2)
-/// bit 14-15: special move flag: promotion (1), en passant (2), castling (3)
-/// NOTE: EN-PASSANT bit is set only when a pawn can be captured
+/// bit 12-15: special bits as described below
 ///
-/// Gating moves are encoded by adding (gated piece type - ROOK) in bits 12-13.
+/// NORMAL moves have bits 14 and 15 set to 0. We encode gating of HAWK,
+/// ELEPHANT or QUEEN by adding (gated piece type - ROOK) in bits 12-13.
 ///
-/// For castling moves where a piece is gated on the rook square, bits 14-15
-/// are changed to PROMOTION in order to distinguish them from castling moves
-/// where the piece is gated on the king's origin square.
+/// ENPASSANT moves are encoded with bit 14 set to 1 and bit 15 set to 0.
+/// NOTE: ENPASSANT is set only when a pawn can be captured.
 ///
-/// Promotions to HAWK, ELEPHANT or QUEEN are encoded by settting bits 14-15
-/// to ENPASSANT, and bits 12-13 are set to (promoted piece type - ROOK).
+/// PROMOTION and CASTLING moves have bit 15 set. We distinguish between
+/// promotions and castlings by checking the parities of the ranks of the to
+/// and from square. If they are different it is a PROMOTION otherwise it is
+/// a CASTLING. For technical reasons we do this test in bit 3 so it is
+/// convenient to set CASTLING = 1 << 15 and PROMOTION = CASTLING | 8.
+///
+/// With promotions and castlings we have bits 12-14 free to store further
+/// information. For promotions we use these bits to encode the promotion
+/// type ranging from 2 for KNIGHT up to 7 for QUEEN. With castling moves we
+/// set bit 14 if gating takes place on the square of the rook. We encode
+/// the gated piece just as for NORMAL moves.
 ///
 /// Special cases are MOVE_NONE and MOVE_NULL. We can sneak these in because in
 /// any normal move destination square is always different from origin square
@@ -131,11 +138,10 @@ enum Move : int {
 
 enum MoveType {
   NORMAL,
-  PROMOTION  = 1 << 14,
-  ENPASSANT  = 2 << 14,
-  CASTLING   = 3 << 14,
-  PROMOTION2 = ENPASSANT,
-  CASTLING2  = PROMOTION
+  ENPASSANT = 1 << 14,
+  CASTLING  = 1 << 15,
+  PROMOTION = CASTLING | 8,
+  CASTLING2 = CASTLING | (1 << 14)
 };
 
 enum Color {
@@ -208,7 +214,8 @@ enum Value : int {
 enum PieceType {
   NO_PIECE_TYPE, PAWN, KNIGHT, BISHOP, ROOK, HAWK, ELEPHANT, QUEEN, KING,
   ALL_PIECES = 0,
-  PIECE_TYPE_NB = 9
+  PIECE_TYPE_NB = 9,
+  NO_GATE = ROOK
 };
 
 enum Piece {
@@ -438,26 +445,31 @@ inline int from_to(Move m) {
  return m & 0xFFF;
 }
 
-inline bool is_gating(Move m) {
-  return (m & (3 << 12)) && (rank_of(from_sq(m)) == RANK_1 || rank_of(from_sq(m)) == RANK_8) && ((m & (3 << 14)) == NORMAL || (m & (3 << 14)) == CASTLING || rank_of(from_sq(m)) == rank_of(to_sq(m)));
-}
-
-inline bool gating_on_castling_rook(Move m) {
-  return (m & (3 << 14)) == PROMOTION && (m & (3 << 12)) && rank_of(from_sq(m)) == rank_of(to_sq(m));
-}
-
 inline MoveType type_of(Move m) {
-  if ((m & (3 << 14)) == PROMOTION2 && (m & (3 << 12)))
-      return PROMOTION;
-  if (gating_on_castling_rook(m))
-      return CASTLING;
-  return MoveType(m & (3 << 14));
+  return MoveType(m & CASTLING ? (m ^ (m >> 6)) & PROMOTION : m & ENPASSANT);
+}
+
+inline bool is_normal(Move m) {
+  return !(m & (3 << 14));
 }
 
 inline PieceType promotion_type(Move m) {
-  if ((m & (3 << 14)) == PROMOTION2)
-      return PieceType(((m >> 12) & 3) + ROOK);
-  return PieceType(((m >> 12) & 3) + KNIGHT);
+  assert(type_of(m) == PROMOTION);
+  return PieceType((m >> 12) - (CASTLING >> 12));
+}
+
+inline bool is_gating(Move m) {
+  return (m & (3 << 12)) && (is_normal(m) || !((m ^ (m >> 6)) & 8));
+}
+
+inline PieceType gating_type(Move m) {
+  assert(type_of(m) == NORMAL || type_of(m) == CASTLING);
+  return PieceType(((m >> 12) & 3) + NO_GATE);
+}
+
+inline bool gating_on_to_sq(Move m) {
+  assert(type_of(m) == NORMAL || type_of(m) == CASTLING);
+  return m & (1 << 14);
 }
 
 inline Move make_move(Square from, Square to) {
@@ -465,14 +477,9 @@ inline Move make_move(Square from, Square to) {
 }
 
 template<MoveType T>
-inline Move make(Square from, Square to, PieceType pt = KNIGHT) {
-  if (pt > ROOK)
-      return Move(T + ((pt - ROOK) << 12) + (from << 6) + to);
-  return Move(T + ((pt - KNIGHT) << 12) + (from << 6) + to);
-}
-
-inline PieceType gating_type(Move m) {
-  return PieceType(((m >> 12) & 3) + ROOK);
+inline Move make(Square from, Square to, PieceType pt = NO_GATE) {
+  PieceType pt_encode = pt - (T == PROMOTION ? NO_PIECE_TYPE : NO_GATE);
+  return Move((T & (3 << 14)) + (pt_encode << 12) + (from << 6) + to);
 }
 
 inline bool is_ok(Move m) {

--- a/src/types.h
+++ b/src/types.h
@@ -446,6 +446,8 @@ inline int from_to(Move m) {
 }
 
 inline MoveType type_of(Move m) {
+  // If the conditional is true we return either CASTLING
+  // or PROMOTION, otherwise we return NORMAL or ENPASSANT.
   return MoveType(m & CASTLING ? (m ^ (m >> 6)) & PROMOTION : m & ENPASSANT);
 }
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -288,11 +288,14 @@ string UCI::move(Move m, bool chess960) {
   if (m == MOVE_NULL)
       return "0000";
 
-  if (gating_on_castling_rook(m))
-      from = to_sq(m), to = from_sq(m);
+  else if (type_of(m) == CASTLING)
+  {
+      if (gating_on_to_sq(m))
+          from = to_sq(m), to = from_sq(m);
 
-  else if (type_of(m) == CASTLING && !chess960)
-      to = make_square(to > from ? FILE_G : FILE_C, rank_of(from));
+      if (!chess960)
+          to = make_square(to > from ? FILE_G : FILE_C, rank_of(from));
+  }
 
   string move = UCI::square(from) + UCI::square(to);
 


### PR DESCRIPTION
This patch changes the move encoding. I believe it is nicer and also faster. The main idea is to have the top bit represent promotions _and_ castlings. We differentiate between promotions and castlings by looking at the to/from squares. I think the trick I found for doing this is nice.

Doing it this way has the advantage that for castling/promotion there are now 3 free bits to encode more data. For promotions we can use the simplest possible encoding of piece type and for castlings we can use the extra bit to signify gating on the rook square. I wrote detailed comments about this in types.h.

The patch changes bench but again I claim this is for trivial reasons. If you take master and change search.cpp line 595 to:

```
    posKey = pos.key() ^ Key(12345); // was Key(excludedMove)
```

then master and the equivalent version of this branch give the same bench number. Having done this I did a make profile-build and did speed test between this branch and master with ./stockfish bench 16 1 20. On average over 3 runs the gain in speed was close to 2%.