### PR TITLE
Fix update of gates when castling

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -770,6 +770,9 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   assert(captured == NO_PIECE || color_of(captured) == (type_of(m) != CASTLING ? them : us));
   assert(type_of(captured) != KING);
 
+  // Remove gates.
+  st->gatesBB &= ~(SquareBB[from] | SquareBB[to]);
+
   if (type_of(m) == CASTLING)
   {
       assert(pc == make_piece(us, KING));
@@ -896,18 +899,11 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       Piece gating_piece = make_piece(sideToMove, gating_type(m));
       put_piece(gating_piece, gating_square);
       remove_from_hand(sideToMove, gating_type(m));
-      st->gatesBB = st->gatesBB & ~SquareBB[gating_square];
       st->psq += PSQT::psq[gating_piece][gating_square] - PSQT::inhand[gating_piece];
       k ^= Zobrist::psq[gating_piece][gating_square] ^ Zobrist::inhand[gating_piece];
       st->materialKey ^= Zobrist::psq[gating_piece][pieceCount[gating_piece]-1];
       st->nonPawnMaterial[us] += PieceValue[MG][gating_piece];
   }
-
-  // Remove gate
-  if (gates(us) & from)
-      st->gatesBB ^= from;
-  if (type_of(m) == CASTLING || (gates(them) & to))
-      st->gatesBB ^= to;
 
   // Update incremental scores
   st->psq += PSQT::psq[pc][to] - PSQT::psq[pc][from];


### PR DESCRIPTION
I was working on Chess960 castling and couldn't work out why I was getting a change to the bench number. It turns out that master has a bug where gatesBB is updated incorrectly in case of castling moves. Commit message is repeated below:



Although to_sq(m) is the rook square, the variable "to" gets changed
to the destination square of the king by "do_castling" and so the
line st->gatesBB ^= to is wrong in the case of castling.

To trigger this bug compile with debug=yes and then do:

./stockfish
position fen 4k3/8/8/8/8/8/8/4K2R[E] w K - 0 1 moves e1g1 e8d8 g1h1E

It will run without an assertion error even though g1 is not a valid
gating square at move 2.

The fix is to amend st->gatesBB before "to" is changed. Hopefully in
a simpler way without bugs.