### PR TITLE
More fixes for Chess960

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -810,7 +810,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   assert(captured == NO_PIECE || color_of(captured) == (type_of(m) != CASTLING ? them : us));
   assert(type_of(captured) != KING);
 
-  // Remove gates. When castling 'to' will soon be modified so do this now.
+  // Remove gates. When castling, 'to' will soon be modified, so do this now.
   Bitboard lostGates = st->gatesBB & (SquareBB[from] | SquareBB[to]);
 
   if (type_of(m) == CASTLING)

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -810,7 +810,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   assert(captured == NO_PIECE || color_of(captured) == (type_of(m) != CASTLING ? them : us));
   assert(type_of(captured) != KING);
 
-  // Remove gates. This might be too many gates when castling in Chess960!
+  // Remove gates. When castling 'to' will soon be modified so do this now.
   Bitboard lostGates = st->gatesBB & (SquareBB[from] | SquareBB[to]);
 
   if (type_of(m) == CASTLING)
@@ -820,13 +820,6 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
 
       Square rfrom, rto;
       do_castling<true>(us, from, to, rfrom, rto);
-
-      // Prevent gates being incorrectly removed in obscure Chess960 cases
-      if (is_chess960())
-      {
-          if (from  == to ) lostGates &= ~SquareBB[from ];
-          if (rfrom == rto) lostGates &= ~SquareBB[rfrom];
-      }
 
       st->psq += PSQT::psq[captured][rto] - PSQT::psq[captured][rfrom];
       k ^= Zobrist::psq[captured][rfrom] ^ Zobrist::psq[captured][rto];

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -267,6 +267,7 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Th
           for (rsq = relative_square(c, SQ_H1); piece_on(rsq) != rook; --rsq) {}
           st->gatesBB |= rsq;
           st->gatesBB |= square<KING>(c);
+          set_castling_right(c, rsq);
       }
 
       else if (token == 'Q')
@@ -274,24 +275,33 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Th
           for (rsq = relative_square(c, SQ_A1); piece_on(rsq) != rook; ++rsq) {}
           st->gatesBB |= rsq;
           st->gatesBB |= square<KING>(c);
+          set_castling_right(c, rsq);
       }
 
       else if (token >= 'A' && token <= 'H')
       {
           rsq = make_square(File(token - 'A'), relative_rank(c, RANK_1));
           st->gatesBB |= rsq;
-          continue;
+
+          // Maintain compatibility with Chess960 FENs where an unmoved
+          // king is not mentioned if castling is available.
+          if (empty_hand(c))
+              set_castling_right(c, rsq);
       }
-
-      else
-          continue;
-
-      set_castling_right(c, rsq);
   }
+
+  // In Chess960 give castling rights if king and rook are unmoved
+  for (Color c = WHITE; c <= BLACK; ++c)
+      if (isChess960 && (gates(c) & pieces(KING)))
+      {
+          Bitboard castling_rooks = gates(c) & pieces(ROOK);
+          while (castling_rooks)
+              set_castling_right(c, pop_lsb(&castling_rooks));
+      }
 
   // Remove any possible gating squares if no pieces in hand
   for (Color c = WHITE; c <= BLACK; ++c)
-      if (!in_hand(c, HAWK) && !in_hand(c, ELEPHANT) && !in_hand(c, QUEEN))
+      if (empty_hand(c))
           st->gatesBB ^= gates(c);
 
   // 4. En passant square. Ignore if no pawn capture is possible
@@ -477,39 +487,57 @@ const string Position::fen() const {
           ss << '/';
   }
 
-  ss << '[';
-  for (Color c = WHITE; c <= BLACK; ++c)
-      for (PieceType pt = HAWK; pt <= QUEEN; ++pt)
-          ss << std::string(in_hand(c, pt), PieceToChar[make_piece(c, pt)]);
-  ss << ']';
+  if (!empty_hand(WHITE) || !empty_hand(BLACK))
+  {
+      ss << '[';
+      for (Color c = WHITE; c <= BLACK; ++c)
+          for (PieceType pt = HAWK; pt <= QUEEN; ++pt)
+              ss << std::string(in_hand(c, pt), PieceToChar[make_piece(c, pt)]);
+      ss << ']';
+  }
 
   ss << (sideToMove == WHITE ? " w " : " b ");
 
-  if (can_castle(WHITE_OO))
-      ss << 'K';
+  for (Color c = WHITE; c <= BLACK; ++c)
+  {
+      char A = c == WHITE ? 'A' : 'a';
+      char K = c == WHITE ? 'K' : 'k';
+      char Q = c == WHITE ? 'Q' : 'q';
 
-  if (can_castle(WHITE_OOO))
-      ss << 'Q';
+      if (empty_hand(c))
+      {
+          if (can_castle(c | KING_SIDE))
+              ss << (chess960 ? char(A + file_of(castling_rook_square(c |  KING_SIDE))) : K);
 
-  for (File f = FILE_A; f <= FILE_H; ++f)
-      if (   (gates(WHITE) & make_square(f, RANK_1))
-          && (!can_castle(WHITE_OO)  || f != file_of(castling_rook_square(WHITE_OO)))
-          && (!can_castle(WHITE_OOO) || f != file_of(castling_rook_square(WHITE_OOO)))
-          && (!can_castle(WHITE)     || f != file_of(square<KING>(WHITE))))
-          ss << char('A' + f);
+          if (can_castle(c | QUEEN_SIDE))
+              ss << (chess960 ? char(A + file_of(castling_rook_square(c | QUEEN_SIDE))) : Q);
+      }
+      else
+      {
+          Bitboard castlers = 0;
 
-  if (can_castle(BLACK_OO))
-      ss << 'k';
+          if (!chess960)
+          {
+              if (can_castle(c | KING_SIDE))
+              {
+                  ss << K;
+                  castlers |= square<KING>(c);
+                  castlers |= castling_rook_square(c | KING_SIDE);
+              }
 
-  if (can_castle(BLACK_OOO))
-      ss << 'q';
-
-  for (File f = FILE_A; f <= FILE_H; ++f)
-      if (   (gates(BLACK) & make_square(f, RANK_8))
-          && (!can_castle(BLACK_OO)  || f != file_of(castling_rook_square(BLACK_OO)))
-          && (!can_castle(BLACK_OOO) || f != file_of(castling_rook_square(BLACK_OOO)))
-          && (!can_castle(BLACK)     || f != file_of(square<KING>(BLACK))))
-          ss << char('a' + f);
+              if (can_castle(c | QUEEN_SIDE))
+              {
+                  ss << Q;
+                  castlers |= square<KING>(c);
+                  castlers |= castling_rook_square(c | QUEEN_SIDE);
+              }
+          }
+                  
+          for (File f = FILE_A; f <= FILE_H; ++f)
+              if (gates(c) & ~castlers & file_bb(f))
+                  ss << char(A + f);
+      }
+  }
 
   if (!can_castle(WHITE) && !can_castle(BLACK) && !gates(WHITE) && !gates(BLACK))
       ss << '-';
@@ -922,7 +950,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
       k ^= Zobrist::psq[gating_piece][gating_square] ^ Zobrist::inhand[gating_piece];
       st->materialKey ^= Zobrist::psq[gating_piece][pieceCount[gating_piece]-1];
       st->nonPawnMaterial[us] += PieceValue[MG][gating_piece];
-      if (!in_hand(us, HAWK) && !in_hand(us, ELEPHANT) && !in_hand(us, QUEEN))
+      if (empty_hand(us))
           lostGates |= gates(us);
   }
 

--- a/src/position.h
+++ b/src/position.h
@@ -106,6 +106,7 @@ public:
   bool castling_impeded(CastlingRight cr) const;
   Square castling_rook_square(CastlingRight cr) const;
   bool in_hand(Color c, PieceType pt) const;
+  bool empty_hand(Color c) const;
   Bitboard gates(Color c) const;
 
   // Checking
@@ -273,6 +274,10 @@ inline Square Position::ep_square() const {
 
 inline bool Position::in_hand(Color c, PieceType pt) const {
   return inHand[make_piece(c, pt)];
+}
+
+inline bool Position::empty_hand(Color c) const {
+  return !in_hand(c, HAWK) && !in_hand(c, ELEPHANT) && !in_hand(c, QUEEN);
 }
 
 inline Bitboard Position::gates(Color c) const {

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -293,7 +293,7 @@ string UCI::move(Move m, bool chess960) {
       if (gating_on_to_sq(m))
           from = to_sq(m), to = from_sq(m);
 
-      if (!chess960)
+      else if (!chess960)
           to = make_square(to > from ? FILE_G : FILE_C, rank_of(from));
   }
 


### PR DESCRIPTION
I'm back on this again. Actually most of the code was written over a week ago but it turned out so ugly that I only gained the motivation to do any testing this weekend.

The first commit looks like a clear bug in the transmission of gating moves on a castled rook square.

The second commit is the ugly stuff. One issue is that when playing Chess960 we need to infer castling rights from the gateable pieces as K or Q are no longer guaranteed to appear in the castling field. That is painful but was to be expected.

Another issue was more surprising (to me anyway). From [here](http://www.open-aurec.com/wbforum/viewtopic.php?f=19&t=53266#p200644) I learned that Xboard will revert to standard Chess960 fens if one side has no pieces in hand. For example assume white has a hawk in hand and just two unmoved rooks and a king on the board. To begin with the fen will need to mention all three pieces in the castling field but when white gates the hawk under a rook then only the remaining rook will get mentioned... the king no longer needs to be mentioned.

This all required some further logic but I think it should be working now.

The third commit reverts my interpretation of gating rights of a castled piece that doesn't actually move during castling. Xboard does not appear to agree with my interpretation so I think we should follow that. I wrote some instructions of how to check this in the commit message.

Finally, I worked out how to test this stuff for real with Xboard. First of all I ran 100 super-fast games of standard Seirawan chess using your EPD opening book. This was with Xboard 4.9.1 and the lastest version of UCI2WB from h.g.muller's repo [here](http://winboard.nl/cgi-bin?p=uci2wb.git;a=summary). The command line I used was:

```
xboard -fcp "uci2wb ./stockfish ." -scp "uci2wb ./stockfish ." -mg 100 -variant seirawan -noGUI -tc 0:02 -inc 0.05 -lpf /home/user/variantfishtest/books/seirawan.epd -lpi -1 -sgf seirawan.pgn
```
It finished without any illegal moves.

Then I ran 100 games of Seirawan960 (not 2880) using the command:

```
xboard -fcp "uci2wb ./stockfish ." -scp "uci2wb ./stockfish ." -mg 100 -variant seirawan -noGUI -tc 0:02 -inc 0.05 -shuffleOpenings -fischerCastling -defaultFrcPosition -1 -sgf seirawan960.pgn
```
Also no illegal moves but to get this to work I had to hard code UCI_Chess960 = true in the code as the combination of Xboard and UCI2WB did not send that option across. I suppose this is a minor bug of Xboard.

A more annoying bug of Xboard is that it is not capable of reading back its own PGN. For example if you run the second command and then try to open seirawan960.pgn then you will likely get illegal move errors on the first castling. It appears that Xboard sets up the board correctly but does not infer castling rights from the fen as it should. If this gets committed I will ask h.g.muller about these problems.

I should also mention that this patch series does not change the bench number. Oh, and regarding code style I thought it was worth adding a helper for "empty_hand" because the same condition is used at least three times in the code.