### PR TITLE
Fixes for KEKR endgame

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -56,7 +56,7 @@ namespace {
   };
 
   // Tables used to drive a piece towards or away from another piece
-  const int PushClose[8] = { 0, 0, 100, 80, 60, 40, 20, 10 };
+  const int PushClose[8] = { 0, 120, 100, 80, 60, 40, 20, 10 };
   const int PushAway [8] = { 0, 5, 20, 40, 60, 80, 90, 100 };
 
   // Pawn Rank based scaling factors used in KRPPKRP endgame
@@ -328,7 +328,7 @@ Value Endgame<KEKR>::operator()(const Position& pos) const {
 
   Square winnerKSq = pos.square<KING>(strongSide);
   Square loserKSq = pos.square<KING>(weakSide);
-  Square loserRSq = pos.square<KING>(weakSide);
+  Square loserRSq = pos.square<ROOK>(weakSide);
 
   Value result =  Value(PushToEdges[loserKSq])
                 + PushClose[distance(winnerKSq, loserKSq)]


### PR DESCRIPTION
Hi. I've been silently following the latest developments. Congrats on the two QEH symmetry patches, they look like obvious winners. Also the piece value tuning looks interesting... Elephants seem very strong in the endgame!

The last time I had chance to work on Seirawan was when I saw your KEKR patch from a couple of weeks ago. I got HGM's fairygen working from [here](http://kirill-kryukov.com/chess/discussion-board/viewtopic.php?f=6&t=6258). I can post the working code if you are interested.

By default the program starts from the longest win which is a KEKR position where white converts in 39 moves. It's tricky to find the optimal moves for black but here is a pretty decent game that starts from the longest win:

```
[Date "2018.01.09"]
[Round "-"]
[White "-"]
[Black "-"]
[Result "*"]
[Variant "seirawan"]
[FEN "7k/8/8/8/8/1E2K3/8/5r2[-] w - - 0 1"]
[SetUp "1"]

1. Kd2 Rf2+ 2. Kc1 Rf1+ 3. Kb2 Rf2+ 4. Ka3 Rf7 5. Eb6 Rf3+ 6. Kb4 Rf4+ 7.
Kc3 Rf3+ 8. Kd4 Kh7 9. Eb1 Rf6 10. Eb7+ Kh6 11. Eb8 Kg5 12. Kc4
```
and now white can win the rook in another 20 moves or so. I think the most interesting moves are the quiet 9.Eb1 and 11.Eb8 that stop the rook moving to the a,b and c files.

This endgame seems really difficult for a 4 piece endgame and I didn't manage to find any code that was able to solve the most difficult positions satisfactorily. However, I did find a couple wrinkles in the current code and that is all that this PR is trying to address.

I'll be watching the Seirawan tests with interest even if I can't contribute before the weekend.

EDIT: Heh. The tuned piece values passed in less time than it took to write this message, congrats.