### PR TITLE
Undo see_ge changes

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1184,15 +1184,12 @@ bool Position::see_ge(Move m, Value threshold) const {
       // Locate and remove the next least valuable attacker
       nextVictim = min_attacker<PAWN>(byTypeBB, to, stmAttackers, occupied, attackers);
 
-      if (nextVictim == KING && stm == sideToMove && is_gating(m) && (gating_type(m) == HAWK ? attacks_bb<HAWK>(from, occupied) : attacks_bb<ELEPHANT>(from, occupied)))
-          nextVictim = gating_type(m);
       if (nextVictim == KING)
       {
           // Our only attacker is the king. If the opponent still has
           // attackers we must give up. Otherwise we make the move and
           // (having no more attackers) the opponent must give up.
-          if (   !(attackers & pieces(~stm))
-              && !(~stm == sideToMove && is_gating(m) && (gating_type(m) == HAWK ? attacks_bb<HAWK>(from, occupied) : attacks_bb<ELEPHANT>(from, occupied))))
+          if (!(attackers & pieces(~stm)))
               opponentToMove = !opponentToMove;
           break;
       }


### PR DESCRIPTION
The subexpression:

gating_type(m) == HAWK ? attacks_bb<HAWK>(from, occupied)
                       : attacks_bb<ELEPHANT>(from, occupied);

always evaluates to true. I suppose that an "& to" was intended to appear
but it doesn't.

Effectively this means that when we consider SEE sequences, the opponent
king is never allowed to make a capture if the first move was a gating
move and when we make a gating move ourselves, should our king ever get
involved in the sequence then we can substitue our gated piece even if
it doesn't attack the destination square.

This commit reverts to the plain chess version. SPRT(-10, 0) tests were
run in order to verify no significant regression.

STC:
LLR: 2.95 (-2.94,2.94) [-10.00,0.00]
Total: 4648 W: 1420 L: 1403 D: 1825

LTC:
LLR: 2.97 (-2.94,2.94) [-10.00,0.00]
Total: 3753 W: 1036 L: 1008 D: 1709

Bench: 2448041