### PR TITLE
Increase bench depth

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -61,7 +61,7 @@ vector<string> setup_bench(const Position& current, istream& is) {
   // Assign default values to missing arguments
   string ttSize    = (is >> token) ? token : "16";
   string threads   = (is >> token) ? token : "1";
-  string limit     = (is >> token) ? token : "13";
+  string limit     = (is >> token) ? token : "15";
   string fenFile   = (is >> token) ? token : "default";
   string limitType = (is >> token) ? token : "depth";
 


### PR DESCRIPTION
I just wonder if we can trigger any failure by increasing the bench depth?

Bench: 6397622