### PR TITLE
Tablebase fixes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -604,7 +604,8 @@ namespace {
         if (    piecesCount <= TB::Cardinality
             && (piecesCount <  TB::Cardinality || depth >= TB::ProbeDepth)
             &&  pos.rule50_count() == 0
-            && !pos.can_castle(ANY_CASTLING))
+            && !pos.can_castle(ANY_CASTLING)
+            && !pos.gates(WHITE) && !pos.gates(BLACK))
         {
             TB::ProbeState err;
             TB::WDLScore v = Tablebases::probe_wdl(pos, &err);
@@ -1605,6 +1606,9 @@ void Tablebases::filter_root_moves(Position& pos, Search::RootMoves& rootMoves) 
     }
 
     if (Cardinality < popcount(pos.pieces()) || pos.can_castle(ANY_CASTLING))
+        return;
+
+    if (pos.gates(WHITE) || pos.gates(BLACK))
         return;
 
     // Don't filter any moves if the user requested analysis on multiple

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -216,7 +216,7 @@ const Value WDL_to_value[] = {
     VALUE_MATE - MAX_PLY - 1
 };
 
-const std::string PieceToChar = " PNBRQK  pnbrqk";
+const std::string PieceToChar = " PNBRHEQK pnbrheqk";
 
 int Binomial[6][SQUARE_NB];    // [k][n] k elements from a set of n elements
 int LeadPawnIdx[5][SQUARE_NB]; // [leadPawnsCnt][SQUARE_NB]


### PR DESCRIPTION
Two items:

1. Initialisation of tablebases has been causing crashes since the
PieceType reordering.

2. TBs should not be called when there are still gate squares available.

The second point could be fixed by incorpoating hand information in the
material key but just go with the simple solution for now.

No functional change