### PR TITLE
Ensure empty squares are not gateable

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -298,6 +298,9 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si, Th
               set_castling_right(c, pop_lsb(&castling_rooks));
       }
 
+  // Remove bogus gate squares. Should only happen with incorrect FENs.
+  st->gatesBB &= pieces() & (Rank1BB | Rank8BB);
+
   // Remove any possible gating squares if no pieces in hand
   for (Color c = WHITE; c <= BLACK; ++c)
       if (empty_hand(c))


### PR DESCRIPTION
Since benchmark.cpp contains FENs where empty squares are listed as gateable this is actually a functional change. Because Xboard 4.9.1 can also list empty squares as gateable (e.g. go to Edit Position, remove the white queen, go to Copy Position and D still ends up in the castling field) this might be worth adding.